### PR TITLE
F2F-1017: Create alerting for fatal errors in FE and BE

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -338,6 +338,41 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref ECSAccessLogsGroup
 
+  ECSFatalErorMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ECSAccessLogsGroup
+      FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
+      MetricTransformations:
+        -
+          MetricValue: "1"
+          MetricNamespace: !Sub "${AWS::StackName}/LogMessages"
+          MetricName: "ECSFatalerror-message"
+
+  ECSFatalErrorAlarm:
+    DependsOn:
+      - "ECSFatalErorMetricFilter"
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-ECSFatalErrorAlarm"
+      AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs"
+      ActionsEnabled: true
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      InsufficientDataActions: [ ]
+      MetricName: ECSFatalerror-message
+      Namespace: !Sub "${AWS::StackName}/LogMessages"
+      Statistic: Sum
+      Dimensions: [ ]
+      Period: 60
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
 
   # Fargate tasks
 
@@ -550,6 +585,42 @@ Resources:
         !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
       FilterPattern: ""
       LogGroupName: !Ref APIGWAccessLogsGroup
+
+  APIGWFatalErorMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref APIGWAccessLogsGroup
+      FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
+      MetricTransformations:
+        -
+          MetricValue: "1"
+          MetricNamespace: !Sub "${AWS::StackName}/LogMessages"
+          MetricName: "APIGWFatalerror-message"
+
+  APIGWFatalErrorAlarm:
+    DependsOn:
+      - "APIGWFatalErorMetricFilter"
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-APIGWFatalErrorAlarm"
+      AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs"
+      ActionsEnabled: true
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      InsufficientDataActions: [ ]
+      MetricName: APIGWFatalerror-message
+      Namespace: !Sub "${AWS::StackName}/LogMessages"
+      Statistic: Sum
+      Dimensions: [ ]
+      Period: 60
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
 
 
   # Autoscaling


### PR DESCRIPTION

![Screenshot 2023-08-09 at 14 55 48](https://github.com/alphagov/di-ipvreturn-front/assets/131283983/29fd1e0a-aa15-4de9-a214-5926c10a1f9f)
Create a metric filter for FE APIGW & ECS if log message contains level is FATAL or message has Exception Unhandled
Create a cloud watch alarm if the log group finds the metric filter
Stack notification is sent if the alarm is triggered
tested manually writing a Fatal error log on the log messages

- [F2F-1017](https://govukverify.atlassian.net/browse/F2F-1017)


[F2F-1017]: https://govukverify.atlassian.net/browse/F2F-1017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ