### PR TITLE
KIWI-1322: Github MIgrations - Post cleanup for IPVReturn Front

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # This is the CODEOWNERS file. These owners will be the default owners for everything in the di-ipvreturn-front repository
 # The following below will be requested for review when someone opens a pull request.
 
-* @alphagov/di-ipv-kiwi-front-codeowners
+* @govuk-one-login/kiwi-front-codeowners
 
 # The following allows QA to review changes to /tests directory
 
-tests/ @alphagov/di-ipv-kiwi-qa-codeowners @alphagov/di-ipv-kiwi-front-codeowners
+tests/ @govuk-one-login/kiwi-qa-codeowners @govuk-one-login/kiwi-front-codeowners


### PR DESCRIPTION
- Add the CODEOWNERS for new govuk-one-login github IPVReturn Front

- [F2F-1322](https://govukverify.atlassian.net/browse/F2F-1322)
