### PR TITLE
KIWI-1486: Add secrets baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -128,37 +128,37 @@
         "filename": "template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 483
+        "line_number": 485
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
         "is_verified": false,
-        "line_number": 485
+        "line_number": 487
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
         "is_verified": false,
-        "line_number": 486
+        "line_number": 488
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 489
+        "line_number": 491
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 491
+        "line_number": 493
       }
     ]
   },
-  "generated_at": "2023-12-05T09:42:43Z"
+  "generated_at": "2024-01-15T09:27:54Z"
 }


### PR DESCRIPTION
## Proposed changes

AWS Security compliance to add security rule for load balance
secrets baseline failed

### What changed

Enabled alb-http-drop-invalid-header-enabled set to true
update secrets baseline

### Why did it change

Security Compliance recommendation

### Issue tracking

- [KIWI-1486](https://govukverify.atlassian.net/browse/KIWI-1486)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->

[KIWI-1486]: https://govukverify.atlassian.net/browse/KIWI-1486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ