### PR TITLE
IPS-486: Add pre-commit github workflow and update hooks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,13 @@
+name: pre-commit
+
+on: push
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+    - uses: pre-commit/action@v3.0.0
+      with:
+        extra_args: "detect-secrets --all-files"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,14 +9,67 @@ repos:
       - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: "v8.30.0" # Use the sha / tag you want to point at
+    rev: "v9.0.0-alpha.2" # Use the sha / tag you want to point at
     hooks:
       - id: eslint
         files: \.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
         types: [file]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v3.0.0-alpha.4"
+    rev: "v4.0.0-alpha.8"
     hooks:
       - id: prettier
         types_or: ["javascript", "ts", "json"]
-# - repo: https://github.com/mattlqx/pre-commit-sign
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: detect-private-key
+      - id: detect-aws-credentials
+        args: ['--allow-missing-credentials']
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+      - id: check-merge-conflict
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.4
+    hooks:
+      - id: remove-tabs
+      - id: remove-crlf
+  - repo: https://github.com/mattlqx/pre-commit-search-and-replace
+    rev: v1.0.5
+    hooks:
+      - id: search-and-replace
+        stages: [commit-msg, commit]
+  - repo: https://github.com/psf/black
+    rev: 24.1.1
+    hooks:
+      - id: black
+        exclude: ^.*-hook/src/.*/models.py$
+        additional_dependencies: ['click==8.0.4']
+  - repo: https://github.com/pycqa/flake8
+    rev: '7.0.0'
+    hooks:
+      - id: flake8
+        exclude: ^.*\.aws-sam.*$
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        name: isort (python)
+        exclude: ^.*-hook/src/.*/models.py$
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.11.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        args: ['--verbose']
+        verbose: true  # print warnings
+  - repo: https://github.com/aws-cloudformation/cfn-python-lint
+    rev: v0.85.0
+    hooks:
+      - id: cfn-python-lint
+        files: ^(?!\..*).*/template\.(json|yml|yaml)$
+  - repo: https://github.com/bridgecrewio/checkov.git
+    rev: '3.2.3'
+    hooks:
+      - id: checkov
+        verbose: true
+        args: [--soft-fail]

--- a/.pre-commit-search-and-replace.yaml
+++ b/.pre-commit-search-and-replace.yaml
@@ -1,0 +1,5 @@
+---
+- search: /artefact/
+  insensitive: true
+  description: >
+    British spelling of "artefact" is not used, use "artifact" instead.

--- a/README.md
+++ b/README.md
@@ -34,3 +34,71 @@ docker push 489145412748.dkr.ecr.eu-west-2.amazonaws.com/YOUR_REPO:YOUR_TAG
 ```
 
 Then to use this new image update the `Image:` tag in the template.yaml and redeploy your template locally in to your own stack in DEV.
+
+
+## Pre-Commit Checking / Verification
+
+There is a `.pre-commit-config.yaml` configuration setup in this repo, this uses [pre-commit](https://pre-commit.com/) to verify your commit before actually commiting, it runs the following checks:
+
+- Check Json files for formatting issues
+- Fixes end of file issues (it will auto correct if it spots an issue - you will need to run the git commit again after it has fixed the issue)
+- It automatically removes trailing whitespaces (again will need to run commit again after it detects and fixes the issue)
+- Detects aws credentials or private keys accidentally added to the repo
+- runs cloud formation linter and detects issues
+- runs checkov and checks for any issues.
+
+### Dependency Installation
+
+To use this locally you will first need to install the dependencies, this can be done in 2 ways:
+
+#### Method 1 - Python pip
+
+Run the following in a terminal:
+
+```
+sudo -H pip3 install checkov pre-commit cfn-lint
+```
+
+this should work across platforms
+
+#### Method 2 - Brew
+
+If you have brew installed please run the following:
+
+```
+brew install pre-commit ;\
+brew install cfn-lint ;\
+brew install checkov
+```
+
+### Post Installation Configuration
+
+once installed run:
+
+```
+pre-commit install
+```
+
+To update the various versions of the pre-commit plugins, this can be done by running:
+
+```
+pre-commit autoupdate && pre-commit install
+```
+
+This will install / configure the pre-commit git hooks, if it detects an issue while committing it will produce an output like the following:
+
+```
+ git commit -a
+check json...........................................(no files to check)Skipped
+fix end of files.........................................................Passed
+trim trailing whitespace.................................................Passed
+detect aws credentials...................................................Passed
+detect private key.......................................................Passed
+AWS CloudFormation Linter................................................Failed
+- hook id: cfn-python-lint
+- exit code: 4
+W3011 Both UpdateReplacePolicy and DeletionPolicy are needed to protect Resources/PublicHostedZone from deletion
+core/deploy/dns-zones/template.yaml:20:3
+Checkov..............................................(no files to check)Skipped
+- hook id: checkov
+```


### PR DESCRIPTION
### What changed

- Added pre-commit github workflow and update hooks
- Updated readme

### Why did it change

Align pre-commit workflows with other repos across One Login programme

### Issue tracking
- [IPS-486](https://govukverify.atlassian.net/browse/IPS-486)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[IPS-486]: https://govukverify.atlassian.net/browse/IPS-486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ