### PR TITLE
IPS-690: Deploy Cloudfront Origin records all all IPVReturn environments

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -114,51 +114,51 @@
         "filename": "template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 101
+        "line_number": 98
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 137
+        "line_number": 134
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 497
+        "line_number": 494
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
         "is_verified": false,
-        "line_number": 499
+        "line_number": 496
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
         "is_verified": false,
-        "line_number": 500
+        "line_number": 497
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 503
+        "line_number": 500
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 505
+        "line_number": 502
       }
     ]
   },
-  "generated_at": "2024-05-13T13:10:38Z"
+  "generated_at": "2024-05-14T15:25:10Z"
 }

--- a/template.yaml
+++ b/template.yaml
@@ -69,9 +69,6 @@ Conditions:
   DeployAlarms: !Or
     - Condition: IsNotDevelopment
     - !Equals [!Ref DeployAlarmsInDev, true]
-  IsCloudFrontPilotTesting: !Equals
-    - !Ref Environment
-    - dev
 
 Mappings:
   PlatformConfiguration:
@@ -642,7 +639,6 @@ Resources:
           }
   WAFv2ACLAssociation:
     Type: AWS::WAFv2::WebACLAssociation
-    Condition: IsNotDevelopment
     Properties:
       ResourceArn: !Ref LoadBalancer
       WebACLArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Security/Block/WafArn}}"
@@ -765,7 +761,6 @@ Resources:
 
   IPRFrontApiOriginRecord:
     Type: AWS::Route53::RecordSet
-    Condition: IsCloudFrontPilotTesting
     Properties:
       Name: !Sub
         - "origin.${DNSSUFFIX}"


### PR DESCRIPTION
## Proposed changes
- Deploy Cloudfront origin on all IPVReturn accounts
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed
- Previously, the cloudfront origin been deployed on dev environment
- Disabled the Web ACL association on the dev environment
- Changed include the web acl association applied on all environments
- Add DNS record on all IPVReturn accounts
<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-690](https://govukverify.atlassian.net/browse/IPS-690)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->




[IPS-690]: https://govukverify.atlassian.net/browse/IPS-690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ