### PR TITLE
IPS-561: Canary deployment on IPVReturn - Step 2 deployment

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -318,21 +318,28 @@ Resources:
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
-      LoadBalancers:
-        - ContainerName: app
-          ContainerPort: 8080
-          TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
-      NetworkConfiguration:
-        AwsvpcConfiguration:
-          AssignPublicIp: DISABLED
-          SecurityGroups:
-            - !GetAtt ECSSecurityGroup.GroupId
-          Subnets:
-            - Fn::ImportValue:
-                !Sub "${VpcStackName}-ProtectedSubnetIdA"
-            - Fn::ImportValue:
-                !Sub "${VpcStackName}-ProtectedSubnetIdB"
-      TaskDefinition: !Ref ECSServiceTaskDefinition
+      LoadBalancers: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - - ContainerName: app
+            ContainerPort: 8080
+            TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
+      NetworkConfiguration: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - AwsvpcConfiguration:
+            AssignPublicIp: DISABLED
+            SecurityGroups:
+              - !GetAtt ECSSecurityGroup.GroupId
+            Subnets:
+              - Fn::ImportValue:
+                  !Sub "${VpcStackName}-ProtectedSubnetIdA"
+              - Fn::ImportValue:
+                  !Sub "${VpcStackName}-ProtectedSubnetIdB"
+      TaskDefinition: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - !Ref ECSServiceTaskDefinition
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-ECS"


### PR DESCRIPTION
This the second step of canary deployment on Stage 2 on frontend. After deploying all the additional stacks for the canary deployment, the load balancer and network configuration and task definition need to switched to the canary stack.

## Proposed changes
- Stage 2 of Canary deployment on the Frontend ECS 
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed
- Shifted the Loadbalancers, network configuration and Task definitions Canary stack
<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-561](https://govukverify.atlassian.net/browse/IPS-561)

## Checklists

### Environment variables or secrets


<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations
![Screenshot 2024-08-14 at 14 08 57](https://github.com/user-attachments/assets/da0c86bc-2fbe-44c3-a044-750224a0465d)

![Screenshot 2024-08-14 at 14 13 04](https://github.com/user-attachments/assets/012999f2-581a-477b-a8d6-660313a11576)

![Screenshot 2024-08-14 at 14 18 28](https://github.com/user-attachments/assets/b93caf4a-ae6b-4ee6-9579-f12e273828b1)


[IPS-561]: https://govukverify.atlassian.net/browse/IPS-561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ