### PR TITLE
[KIWI-1872] - Set AWS CloudWatch log retention to 30 days

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -396,7 +396,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/ecs/${AWS::StackName}-IPRFront-ECS
-      RetentionInDays: 14
+      RetentionInDays: 30
 
   CSLSECSAccessSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
@@ -705,7 +705,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-IPRFront-API-GW-AccessLogs
-      RetentionInDays: 14
+      RetentionInDays: 30
 
   CSLSAPIGWAccessSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->
[ KIWI-1872 ] Set AWS CloudWatch log retention to 30 days

### Proposed changes

### What changed

Updated the CloudFormation template to set the retention period for all CloudWatch log groups to 30 days (1 month)
Modified the EnvironmentConfiguration mapping in the template to ensure consistent 30-day retention 
Applied the change to all Lambda function and API Gateway log groups associated with the Ipvreturn-front API stack

### Why did it change

To standardise log retention periods across all environments
To ensure compliance with data retention policies

Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

[INCIDEN-627](https://govukverify.atlassian.net/browse/INCIDEN-627?focusedCommentId=125675)

- [ CRI-BAV-FRONT ](https://github.com/govuk-one-login/ipv-cri-bav-front/pull/322)
- [ CRI-CIC-FRONT ](https://github.com/govuk-one-login/ipv-cri-cic-front/pull/757)
- [ CRI-F2F-API ](https://github.com/govuk-one-login/ipv-cri-f2f-api/pull/595)
- [ CRI-BAV-API ](https://github.com/govuk-one-login/ipv-cri-bav-api/pull/250)
- [ CRI-F2F-FRONT ](https://github.com/govuk-one-login/ipv-cri-f2f-front/pull/526)
- [ CRI-CIC-API ](https://github.com/govuk-one-login/ipv-cri-cic-api/pull/577)

### Checklists

PII logging

- [x] Verified that no PII data is being logged

Environment variables or secrets
<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

[INCIDEN-627]: https://govukverify.atlassian.net/browse/INCIDEN-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


