### PR TITLE
Update to  exclude the origin load balancer from the regional FMS policy

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -273,6 +273,9 @@ Resources:
           - Key: routing.http.drop_invalid_header_fields.enabled
             Value: true
         - !Ref AWS::NoValue
+      Tags:
+        - Key: FMSRegionalPolicy
+          Value: false
 
   LoadBalancerListenerTargetGroupECS:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'


### PR DESCRIPTION
This is protected by a specific WAF for CloudFront

## Proposed changes

Added tags to exclude the origin load balancer from FMS as it has it's own CloudFront specific WAF

### What changed
Added tags

### Why did it change
to exclude the origin load balancer from FMS as it has it's own CloudFront specific WAF

### Issue tracking
https://govukverify.atlassian.net/browse/IPS-1407