### PR TITLE
[KIWI-2020] - | CM | Set minimum container count for initial scaling load

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -128,44 +132,52 @@
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 108
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 152
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 569
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 571
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 572
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 575
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 577
       }
     ]
-  }
+  },
+  "generated_at": "2025-03-21T09:33:12Z"
 }

--- a/template.yaml
+++ b/template.yaml
@@ -36,14 +36,6 @@ Parameters:
     Description: "The ARN of the permissions boundary to apply when creating IAM roles"
     Type: String
     Default: "none"
-  MaxContainerCount:
-    Description: Maximum number of FE node/express container tasks to allow autoscaling to reach
-    Type: Number
-    Default: 12
-  MinContainerCount:
-    Description: Minimum number of FE node/express container tasks to allow autoscaling to reach
-    Type: Number
-    Default: 3
   EnableScalingInDev:
     Type: Number
     Default: 0
@@ -118,7 +110,8 @@ Mappings:
       REDIRECTURL: "https://return.dev.account.gov.uk/callback"
       DISCOVERYENDPOINT: "https://oidc.staging.account.gov.uk"
       ACCOUNTSDASHBOARD: "https://home.staging.account.gov.uk"
-
+      minECSCount: 1
+      maxECSCount: 4
     build:
       APIBASEURL: "https://api.return.build.account.gov.uk"
       DNSSUFFIX: "return.build.account.gov.uk"
@@ -128,7 +121,8 @@ Mappings:
       REDIRECTURL: "https://return.build.account.gov.uk/callback"
       DISCOVERYENDPOINT: "https://oidc.staging.account.gov.uk"
       ACCOUNTSDASHBOARD: "https://home.staging.account.gov.uk"
-
+      minECSCount: 6
+      maxECSCount: 60
     staging:
       APIBASEURL: "https://api.return.staging.account.gov.uk"
       DNSSUFFIX: "return.staging.account.gov.uk"
@@ -138,7 +132,8 @@ Mappings:
       REDIRECTURL: "https://return.staging.account.gov.uk/callback"
       DISCOVERYENDPOINT: "https://oidc.staging.account.gov.uk"
       ACCOUNTSDASHBOARD: "https://home.staging.account.gov.uk"
-
+      minECSCount: 2
+      maxECSCount: 4
     integration:
       APIBASEURL: "https://api.return.integration.account.gov.uk"
       DNSSUFFIX: "return.integration.account.gov.uk"
@@ -148,7 +143,8 @@ Mappings:
       REDIRECTURL: "https://return.integration.account.gov.uk/callback"
       DISCOVERYENDPOINT: "https://oidc.integration.account.gov.uk"
       ACCOUNTSDASHBOARD: "https://home.integration.account.gov.uk"
-
+      minECSCount: 2
+      maxECSCount: 4
     production:
       APIBASEURL: "https://api.return.account.gov.uk"
       DNSSUFFIX: "return.account.gov.uk"
@@ -158,6 +154,8 @@ Mappings:
       REDIRECTURL: "https://return.account.gov.uk/callback"
       DISCOVERYENDPOINT: "https://oidc.account.gov.uk"
       ACCOUNTSDASHBOARD: "https://home.account.gov.uk"
+      minECSCount: 6
+      maxECSCount: 60
 
 Resources:
   # Security Groups for the ECS service and load balancer
@@ -365,7 +363,7 @@ Resources:
           - UseCanaryDeployment
           - CODE_DEPLOY
           - ECS
-      DesiredCount: !Ref MinContainerCount
+      DesiredCount: !FindInMap [EnvironmentVariables, !Ref Environment, minECSCount]
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
@@ -785,8 +783,10 @@ Resources:
     Condition: EnableScaling
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
-      MaxCapacity: !Ref MaxContainerCount
-      MinCapacity: !Ref MinContainerCount
+      MinCapacity:
+        !FindInMap [EnvironmentVariables, !Ref Environment, minECSCount]
+      MaxCapacity:
+        !FindInMap [EnvironmentVariables, !Ref Environment, maxECSCount]
       ResourceId: !Join
         - '/'
         - - "service"
@@ -1206,7 +1206,7 @@ Resources:
       Dimensions: []
       EvaluationPeriods: 5
       DatapointsToAlarm: 5
-      Threshold: !Ref MaxContainerCount
+      Threshold: !FindInMap [EnvironmentVariables, !Ref Environment, maxECSCount]
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
       Metrics:


### PR DESCRIPTION
### What changed

Set minimum and maximum containers for each environment

### Why did it change

Allow the service to scale appropriately. Capacity is higher in build and production where we do perf tests

- [KIWI-2020](https://govukverify.atlassian.net/browse/KIWI-2020)

[KIWI-2020]: https://govukverify.atlassian.net/browse/KIWI-2020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ