### PR TITLE
KIWI-2412 dependency upgrade addressing critical vulnerability in for…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5035,9 +5035,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "axios": "1.8.2",
     "express": "^4.17.1",
     "winston": "^3.7.2"
+  },
+  "overrides": {
+    "form-data": ">=4.0.4"
   }
 }


### PR DESCRIPTION
### What changed
form-data v4.0.0 -> 4.0.4

### Why did it change
To address critical axios vulnerability

### Issue tracking
[KIWI-2412](https://govukverify.atlassian.net/browse/KIWI-2412)

[KIWI-2412]: https://govukverify.atlassian.net/browse/KIWI-2412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ